### PR TITLE
Added avvisi tab for Trentino trasporti routes

### DIFF
--- a/src/lib/RouteNews.ts
+++ b/src/lib/RouteNews.ts
@@ -1,0 +1,13 @@
+export interface News {
+	id: number;
+	title: string;
+	details: string;
+	startDate: Date;
+	endDate: Date;
+	url: string;
+}
+
+export interface RouteNews {
+	route: number;
+	news: News[];
+}

--- a/src/lib/RouteNews.ts
+++ b/src/lib/RouteNews.ts
@@ -1,3 +1,8 @@
+export interface RouteFe {
+	name: string;
+	color: string;
+}
+
 export interface News {
 	id: number;
 	title: string;
@@ -5,6 +10,7 @@ export interface News {
 	startDate: Date;
 	endDate: Date;
 	url: string;
+	routes: RouteFe[]
 }
 
 export interface RouteNews {

--- a/src/lib/StopGroupDetails.ts
+++ b/src/lib/StopGroupDetails.ts
@@ -1,4 +1,5 @@
 import type { StopDirection } from '$lib/StopDirection';
+import type { News } from '$lib/RouteNews';
 
 export default interface StopGroupDetails {
 	name: string;
@@ -7,4 +8,5 @@ export default interface StopGroupDetails {
 	lastUpdatedAt: Date;
 	directions: StopDirection[];
 	trainStationSlug: string | null;
+	news: News[];
 }

--- a/src/lib/components/NewsTab.svelte
+++ b/src/lib/components/NewsTab.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { News } from "$lib/RouteNews";
+
+	interface Props {
+		newsList: News[];
+		today: Date;
+	}
+
+	let showNews = $state(false);
+
+	const onClick = (evt: Event) => {
+		evt.preventDefault();
+		showNews = !showNews;
+	};
+
+	let { newsList, today }: Props = $props();
+</script>
+
+<div class="flex gap-2">
+	<button
+		class="inline-flex h-8 grow basis-1/3 cursor-pointer items-center justify-center rounded-md px-3 py-5 leading-none no-underline"
+		class:bg-neutral-100={showNews}
+		class:hover:bg-neutral-200={showNews}
+		class:text-neutral-800={showNews}
+		class:font-semibold={showNews}
+		class:bg-neutral-800={!showNews}
+		class:hover:bg-neutral-700={!showNews}
+		onclick={onClick}
+	>
+		{showNews ? 'Nascondi avvisi' : `🔔 Mostra avvisi`}
+	</button>
+</div>
+
+{#if showNews}
+	<div class="flex flex-col gap-2">
+		{#each newsList as news}
+			{#if today >= news.startDate && today <= news.endDate}
+				<div class="rounded-lg bg-neutral-800 px-4 pt-3 pb-4 no-underline">
+					<h2 class="mb-2 text-base leading-tight font-medium">⚠️ {news.title}</h2>
+					<p class="mt-0 text-sm text-neutral-400">{news.details}</p>
+				</div>
+			{/if}
+		{/each}
+	</div>
+{/if}

--- a/src/lib/components/NewsTab.svelte
+++ b/src/lib/components/NewsTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { News } from "$lib/RouteNews";
+	import type { News } from '$lib/RouteNews';
 
 	interface Props {
 		newsList: News[];
@@ -38,6 +38,19 @@
 				<div class="rounded-lg bg-neutral-800 px-4 pt-3 pb-4 no-underline">
 					<h2 class="mb-2 text-base leading-tight font-medium">⚠️ {news.title}</h2>
 					<p class="mt-0 text-sm text-neutral-400">{news.details}</p>
+
+					<div class="flex flex-wrap gap-2 pt-1">
+						<p class="mt-0 size-full text-sm text-neutral-400">Linee interessate:</p>
+
+						{#each news.routes as route}
+							<div
+								class="text-s flex h-5 w-5 shrink-0 items-center justify-center rounded-sm font-medium select-none"
+								style="background-color: {route.color}"
+							>
+								{route.name}
+							</div>
+						{/each}
+					</div>
 				</div>
 			{/if}
 		{/each}

--- a/src/lib/server/route-news.ts
+++ b/src/lib/server/route-news.ts
@@ -1,6 +1,6 @@
 import * as api from '$lib/server/trentino-trasporti-api';
 import NodeCache from 'node-cache';
-import type { RouteNews, News } from '$lib/RouteNews';
+import type { RouteNews, News, RouteFe } from '$lib/RouteNews';
 
 const cache = new NodeCache({
 	stdTTL: 24 * 60 * 60 // 24 hours
@@ -27,7 +27,7 @@ export async function routeNews() {
 
 		apiStop.news.forEach((news) => {
 			const newsId = news.idFeed;
-			const newsInfo = newsCreate(news);
+			const newsInfo = newsCreate(news, apiStops);
 
 			news.routeIds.split(',').forEach((routeId: string) => {
 				const routeIdInt = parseInt(routeId, 10);
@@ -77,13 +77,23 @@ export async function getRouteNews(routes: Set<number>) {
 	return Array.from(uniqueNews.values());
 }
 
-function newsCreate(data: any): News {
+function newsCreate(data: api.ApiNews, apiStop: api.ApiRoute[]): News {
+	const routes: RouteFe[] = data.routeIds.split(',').map((el) => {
+		const routeInfo = apiStop.find((apiEl) => apiEl.routeId === parseInt(el, 10)) as api.ApiRoute;
+
+		return {
+			name: routeInfo.routeShortName,
+			color: `#${routeInfo.routeColor}`
+		};
+	});
+
 	return {
 		title: data.header,
 		details: data.details,
 		id: data.idFeed,
 		startDate: new Date(data.startDate),
 		endDate: new Date(data.endDate),
-		url: data.url
+		url: data.url,
+		routes
 	};
 }

--- a/src/lib/server/route-news.ts
+++ b/src/lib/server/route-news.ts
@@ -1,0 +1,89 @@
+import * as api from '$lib/server/trentino-trasporti-api';
+import NodeCache from 'node-cache';
+import type { RouteNews, News } from '$lib/RouteNews';
+
+const cache = new NodeCache({
+	stdTTL: 24 * 60 * 60 // 24 hours
+});
+
+const routeNewsCacheKey = 'route-news';
+
+export async function routeNews() {
+	// Return from cache if available
+	const cached = cache.get<RouteNews[]>(routeNewsCacheKey);
+
+	if (cached) {
+		return cached;
+	}
+
+	const routeNews: RouteNews[] = [];
+
+	// Fetch stops from the API
+	const apiStops = await api.getRoutes();
+
+	// Group stops by name
+	for (const apiStop of apiStops) {
+		if (!apiStop.news.length) continue;
+
+		apiStop.news.forEach((news) => {
+			const newsId = news.idFeed;
+			const newsInfo = newsCreate(news);
+
+			news.routeIds.split(',').forEach((routeId: string) => {
+				const routeIdInt = parseInt(routeId, 10);
+
+				const routeExisting = routeNews.find((el) => el.route === routeIdInt);
+
+				if (routeExisting) {
+					const newsExisiting = routeExisting.news.find((el) => el.id == newsId);
+
+					if (!newsExisiting) routeExisting.news.push(newsInfo);
+				} else {
+					const newsNew: RouteNews = {
+						route: routeIdInt,
+						news: [newsInfo]
+					};
+
+					routeNews.push(newsNew);
+				}
+			});
+		});
+	}
+
+	cache.set(routeNewsCacheKey, routeNews);
+
+	return routeNews;
+}
+
+export async function getRouteNews(routes: Set<number>) {
+	const routeNewsList = await routeNews();
+
+	const uniqueNews: Map<number, News> = new Map();
+
+	routes.forEach((route) => {
+		const routeEl = routeNewsList.find((el) => {
+			return route === el.route;
+		});
+
+		if (!routeEl) return;
+
+		routeEl.news.forEach((news) => {
+			if (uniqueNews.has(news.id)) return;
+
+			uniqueNews.set(news.id, news);
+		});
+	});
+
+	return Array.from(uniqueNews.values());
+}
+
+function newsCreate(data: any): News {
+	return {
+		title: data.header,
+		details: data.details,
+		id: data.idFeed,
+		startDate: new Date(data.startDate),
+		endDate: new Date(data.endDate),
+		url: data.url
+	};
+}

--- a/src/lib/server/trentino-trasporti-api.ts
+++ b/src/lib/server/trentino-trasporti-api.ts
@@ -11,6 +11,19 @@ if (!building && !BASE_URL) {
 
 const BASIC_AUTH = Buffer.from(env.API_USERNAME + ':' + env.API_PASSWORD).toString('base64');
 
+export interface ApiNews {
+	idFeed: number;
+	agencyId: string;
+	serviceType: string;
+	startDate: string;
+	endDate: string;
+	header: string;
+	details: string;
+	stopId: string;
+	url: string; // this seems to be mainly used for internal purposes
+	routeIds: string;
+}
+
 export interface ApiStop {
 	stopId: number;
 	stopName: string;
@@ -26,6 +39,7 @@ export interface ApiRoute {
 	routeShortName: string;
 	routeLongName: string;
 	routeColor: string | null;
+	news: ApiNews[],
 }
 
 export interface ApiTrip {

--- a/src/routes/[stop]/+page.svelte
+++ b/src/routes/[stop]/+page.svelte
@@ -11,6 +11,7 @@
 	import StopFavoriteButton from '$lib/components/StopFavoriteButton.svelte';
 	import { Flag } from 'lucide-svelte';
 	import { writable } from 'svelte/store';
+	import NewsTab from '$lib/components/NewsTab.svelte';
 
 	let { data } = $props();
 
@@ -18,6 +19,7 @@
 	let showMore = $state(data.details.directions.length < 2);
 	let limit = $derived(showMore ? 15 : 5);
 	let showMoreInProgress = $state(false);
+	let today = new Date();
 
 	const expandedTripId = writable<string | null>(null);
 	setContext('expandedTripId', expandedTripId);
@@ -69,6 +71,15 @@
 				isBus={true}
 				stopSlug={details.canonicalSlug}
 				stationSlug={details.trainStationSlug}
+			/>
+		</div>
+	{/if}
+
+	{#if details.news.length}
+		<div class="mt-6 flex justify-center flex-wrap gap-3">
+			<NewsTab 
+				newsList={details.news} 
+				today={today}
 			/>
 		</div>
 	{/if}


### PR DESCRIPTION
## Issue
In the past few days there were disruptions to the routes due to either strikes or sporting events in the city, for the website it's not entirely if my route will have any disruption or not.

## Proposed solution
The `/routes` endpoint exposes a `news` section for each route  providing additional information regarding any disruption to that route. Therefore i tired adding a section right below the stop to show the news related to the lines for that stop.  

If there are no news to be shown the button doesn't appear (like now).  
I haven't checked in the trains api if there is something similar but i reckon this functionality could also be extended to that part.

Any feedback is more than welcome.

Attached you can see the preview

Closed             |  Open
:-------------------------:|:-------------------------:
<img width="1082" height="2402" alt="avvisi" src="https://github.com/user-attachments/assets/d6612ade-5186-43a2-b6f4-4a6105a8e750" /> | <img width="1082" height="2402" alt="avvisi-open" src="https://github.com/user-attachments/assets/dfa878eb-423a-4c9a-8b4c-14875a120007" /> 